### PR TITLE
Refactor import settings.

### DIFF
--- a/htan_girder/constants.py
+++ b/htan_girder/constants.py
@@ -3,6 +3,4 @@
 
 # Constants representing the setting keys for this plugin
 class PluginSettings(object):
-    HTAN_ASSETSTORE = 'htan.assetstore'
-    HTAN_IMPORT_PATH = 'htan.import_path'
-    HTAN_IMPORT_FOLDER = 'htan.import_folder'
+    HTAN_IMPORT_LIST = 'htan.import_list'

--- a/htan_girder/reimport_job.py
+++ b/htan_girder/reimport_job.py
@@ -1,3 +1,4 @@
+import json
 from threading import RLock
 
 from girder import logger
@@ -7,6 +8,7 @@ from girder.models.setting import Setting
 from girder.models.user import User
 from girder.utility.progress import ProgressContext
 
+from girder_jobs.constants import JobStatus
 from girder_jobs.models.job import Job
 
 from .constants import PluginSettings
@@ -14,19 +16,23 @@ from .constants import PluginSettings
 _reimportStatus = {
     'lock': RLock(),
     'running': None,
-    'rerun': False,
+    'rerun': set(),
 }
 
 
-def reimportData():
+def reimportData(key):
     with _reimportStatus['lock']:
         if not _reimportStatus['running']:
-            startReimportJob()
+            startReimportJob(key)
         else:
-            _reimportStatus['rerun'] = True
+            if key not in _reimportStatus['rerun']:
+                logger.info('Adding future HTAN reimport job for %s.', key)
+            else:
+                logger.info('Already have a future HTAN reimport job for %s.', key)
+            _reimportStatus['rerun'] |= {key}
 
 
-def startReimportJob():
+def startReimportJob(key):
     with _reimportStatus['lock']:
         job = Job().createLocalJob(
             module='htan_girder.reimport_job',
@@ -35,20 +41,33 @@ def startReimportJob():
             type='htan_reimport',
             public=True,
             asynchronous=True,
+            kwargs=dict(key=key),
         )
         _reimportStatus['running'] = True
-        _reimportStatus['rerun'] = False
+        _reimportStatus['rerun'] -= {key}
         logger.info('Scheduling HTAN reimport job.')
         Job().scheduleJob(job)
 
 
-def reimportJob(*args, **kwargs):
+def reimportJob(job):
+    key = job['kwargs']['key']
+    job = Job().updateJob(
+        job, log='Started HTAN reimport job for %s\n' % key,
+        status=JobStatus.RUNNING)
     try:
-        assetstoreId = Setting().get(PluginSettings.HTAN_ASSETSTORE)
-        importPath = Setting().get(PluginSettings.HTAN_IMPORT_PATH) or ''
-        importFolderId = Setting().get(PluginSettings.HTAN_IMPORT_FOLDER)
+        importList = Setting().get(PluginSettings.HTAN_IMPORT_LIST)
+        if not importList:
+            return
+        record = {}
+        for entry in json.loads(importList):
+            if entry.get('key') == key:
+                record = entry
+        assetstoreId = record.get('assetstoreId')
+        importFolderId = record.get('destinationId')
         if not assetstoreId or not importFolderId:
-            logger.info('HTAN reimport job not configured.  An assetstore and folder must be set.')
+            logger.info(
+                'HTAN reimport job for key %s not configured.  An assetstore '
+                'and folder must be set.', key)
             return
         assetstore = Assetstore().load(assetstoreId)
         folder = Folder().load(importFolderId, force=True)
@@ -58,15 +77,32 @@ def reimportJob(*args, **kwargs):
                 'invalid or nonexistant assetstore or folder.')
             return
         admin = User().findOne({'admin': True})
-        logger.info('Starting HTAN reimport job.')
+        logger.info('Starting HTAN reimport job for %s.', key)
         with ProgressContext(True, user=admin, title='Importing data') as ctx:
             Assetstore().importData(
                 assetstore, parent=folder, parentType='folder',
-                params=dict(importPath=importPath), progress=ctx, user=admin,
+                params=dict(
+                    importPath=record.get('importPath', ''),
+                    fileIncludeRegex=record.get('fileIncludeRegex'),
+                    fileExcludeRegex=record.get('fileExcludeRegex'),
+                ), progress=ctx, user=admin,
                 leafFoldersAsItems=False)
-        logger.info('Finished HTAN reimport job.')
+        if record.get('endFunction'):
+            logger.info(
+                'Should now run function %s, but doing so it not implemented',
+                record['endFunction'])
+        logger.info('Finished HTAN reimport job for %s.' % key)
+        job = Job().updateJob(
+            job, log='Finished HTAN reimport job for %s.' % key,
+            status=JobStatus.SUCCESS)
+    except Exception:
+        job = Job().updateJob(
+            job, log='Error running HTAN reimport job for %s\n' % key,
+            status=JobStatus.ERROR)
+        logger.exception('Error running HTAN reimport job for %s', key)
+        return
     finally:
         with _reimportStatus['lock']:
             _reimportStatus['running'] = False
-            if _reimportStatus['rerun']:
-                startReimportJob()
+            if len(_reimportStatus['rerun']):
+                startReimportJob(sorted(_reimportStatus['rerun'])[0])

--- a/htan_girder/rest.py
+++ b/htan_girder/rest.py
@@ -10,12 +10,13 @@ class HTANResource(Resource):
         super().__init__()
         self.resourceName = 'htan'
 
-        self.route('POST', ('reimport', ), self.reimportData)
+        self.route('POST', ('reimport', ':key'), self.reimportData)
 
     @autoDescribeRoute(
         Description('Reimport a folder to an assetstore based on settings.')
+        .param('key', 'The key to reimport.', paramType='path')
     )
     @access.public
-    def reimportData(self):
-        reimportData()
+    def reimportData(self, key):
+        reimportData(key)
         return 'acknowledged'

--- a/htan_girder/web_client/views/ConfigView.pug
+++ b/htan_girder/web_client/views/ConfigView.pug
@@ -1,26 +1,74 @@
+//-
+  htan.import_list
 .g-config-breadcrumb-container
 p.g-htan-description
   | Provides custom tools to support the HTAN project.
-form#g-htan-form(role="form")
-  .form-group
-    label(for="g-htan-assetstore") Import Assetstore
-    input#g-htan-assetstore.form-control.input-sm(
-        type="text", value=settings['htan.assetstore'] || '',
-        title="The ID of the assetstore to use for a dedicated import.")
-  .form-group
-    label(for="g-htan-import-path") Import Path
-    input#g-htan-import-path.form-control.input-sm(
-        type="text", value=settings['htan.import_path'] || '',
-        title="The path within the assetstore to import.")
-  .form-group
-    label(for="g-htan-import-folder") Import Folder
-    .input-group.input-group-sm
-      input#g-htan-import-folder.form-control.input-sm(
-          type="text", value=settings['htan.import_folder'] || '',
-          title="A folder to store imported items.")
-      .input-group-btn
-        button.g-open-browser.btn.btn-default(type="button")
-          i.icon-folder-open
+form#g-htan-form(role='form')
+  table
+    tr
+      th
+      th Name
+      th Description
+      th Import Assetstore ID
+      th Import Path
+      th Import Folder
+      th Include RegEx
+      th Exclude RegEx
+      th End Function
+    -
+      var importList = settings['htan.import_list'] ? JSON.parse(settings['htan.import_list']) : []
+      importList.push({})
+    for row, idx in importList
+      tr(class=idx + 1 !== importList.length ? 'htan-entry' : 'htan-empty-row')
+        td
+          button.g-htan-delete.btn.btn-sm.btn-warning(title='Remove assetstore entry')
+            i.icon-trash
+          button.g-htan-add.btn.btn-sm.btn-warning(title='Add another row')
+            i.icon-plus
+        td
+          input.g-htan-key.form-control.input-sm(
+              htan_prop='key',
+              type='text', value=row.key || '',
+              title='A short name used to trigger the import.')
+        td
+          input.g-htan-desc.form-control.input-sm(
+              htan_prop='desc',
+              type='text', value=row.desc || '',
+              title='A description of this entry.')
+        td
+          input.g-htan-assetstore-id.form-control.input-sm(
+              htan_prop='assetstoreId',
+              type='text', value=row.assetstoreId || '',
+              title='The ID of the assetstore to use for import.')
+        td
+          input.g-htan-importPath.form-control.input-sm(
+              htan_prop='importPath',
+              type='text', value=row.importPath || '',
+              title='The path within the assetstore to import.')
+        td
+          .input-group.input-group-sm
+            input.g-htan-destinationId.form-control.input-sm(
+                htan_prop='destinationId',
+                type='text', value=row.destinationId || '',
+                title='A folder to store import items.')
+            .input-group-btn
+              button.g-open-browser.btn.btn-default(type='button')
+                i.icon-folder-open
+        td
+          input.g-htan-fileIncludeRegex.form-control.input-sm(
+              htan_prop='fileIncludeRegex',
+              type='text', value=row.fileIncludeRegex || '',
+              title='If set, only filenames matching this regular expression will be imported.')
+        td
+          input.g-htan-fileExcludeRegex.form-control.input-sm(
+              htan_prop='fileExcludeRegex',
+              type='text', value=row.fileExcludeRegex || '',
+              title='If set, only filenames that do not match this regular expression will be imported.  If a filename matches the include and exclude regex, it will be excluded.')
+        td
+          input.g-htan-endFunction.form-control.input-sm(
+              htan_prop='endFunction',
+              type='text', value=row.endFunction || '',
+              title='If set, a python module and function to call after import.')
   p#g-htan-error-message.g-validation-failed-message
 .g-htan-buttons
   button#g-htan-save.btn.btn-sm.btn-primary Save

--- a/htan_girder/web_client/views/ConfigView.styl
+++ b/htan_girder/web_client/views/ConfigView.styl
@@ -1,4 +1,15 @@
 #g-htan-form
-  .g-htan-description
-    font-size 12px
-    margin 0 0 2px
+  table
+    width 100%
+    tr:last-child td
+      display none
+    tr:last-child td:first-child
+      display initial
+
+    tr .g-htan-add
+      display none
+    tr:last-child
+      .g-htan-add
+        display initial
+      .g-htan-delete
+        display none


### PR DESCRIPTION
Allow a list of keyed import sets that also include include and exclude regexs.  There are hooks for running a function after the import, but this is not hooked up yet.

This mostly satisfies #1, but the endpoint only takes a single key and doesn't allow overriding other import options.